### PR TITLE
Fix strange scroll behaviour in some browsers

### DIFF
--- a/main.css
+++ b/main.css
@@ -1,3 +1,7 @@
+body {
+    margin: 0px;
+}
+
 .container {
     margin: auto;
     max-width: 700px;


### PR DESCRIPTION
Remove white border around simulation UI, making the UI fill the screen and therefore prevent the default scroll behaviour from overriding the zoom function in some browsers