### PR TITLE
Prevent GUI from duplicating itself on every reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -158,7 +158,6 @@
 			    startstop();
 			    generateInt();
 			    generateStars();
-			    initGUI();
 			}
 		    }
 
@@ -196,7 +195,6 @@
 			    startstop();
 			    generateTar();
 			    generateStars();
-			    initGUI();
 			}
 		    }
 
@@ -243,7 +241,6 @@
 			    startstop();
 			    generateInt();
 			    generateTar();
-			    initGUI();
 			}
 		    }
 
@@ -284,7 +281,6 @@
 			generateInt();
 			generateStars();
 			generateTar();
-			initGUI();
 			camera.position.set( 1, 1, 3 );
 			var Cmpos=CameraPosUp();
 		    }


### PR DESCRIPTION
Prevent each reset from creating a new instance of the GUI overtop of the existing one - this unexpected behavior can be replicated by starting the simulation, clicking reset, then attempting to collapse the GUI, and there will be a second underneath. This patch removes the initGUI code from the reset functions, preventing a new instance from being created each time.