### PR TITLE
Properly update play/pause button on reset

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,6 +119,8 @@
 		    effectController.CameraPos=0;
 		    //when clicked runs reset which pauses and resets the simulation, most parameter changes in the gui will trigger reset
 		    effectController.reset=false;
+			
+		    const gui = new GUI();
 
 		    initGUI();
 		    generateStars();
@@ -246,9 +248,6 @@
 
 		    //set up the GUI for choosing the initial parameters
 		    function initGUI() {
-
-			const gui = new GUI();
-
 			const PositionFolder = gui.addFolder( 'Intruder');
 			PositionFolder.add(effectController, 'int_posx').onChange(generateInt).name('Intruder X (kpc)');
 			PositionFolder.add(effectController, 'int_posy').onChange(generateInt).name('Intruder Y (kpc)');
@@ -283,6 +282,7 @@
 			generateTar();
 			camera.position.set( 1, 1, 3 );
 			var Cmpos=CameraPosUp();
+			gui.foldersRecursive()[2].controllers[1].updateDisplay();
 		    }
 
 		    //pause when restart occurs


### PR DESCRIPTION
When the duplicate GUIs were still present, it appeared to un-tick the play/pause checkbox on each reset (since a blank one would be overlaid on top) - now that they have been removed it now leaves the play/pause box checked if the reset button is clicked while the simulation is active, even though it pauses the simulation itself. This patch accesses the checkbox and calls its existing update function on each reset in order to keep the box synced with the simulation's actual state.